### PR TITLE
update debug api to version 5

### DIFF
--- a/scripts/migrate-imported.rs
+++ b/scripts/migrate-imported.rs
@@ -177,7 +177,7 @@ fn update_runtime_toml(path: &Path) {
 	let toml = std::fs::read_to_string(&path).expect("cannot open runtime toml file");
 	let mut toml = toml.parse::<Document>().expect("invalid runtime toml file");
 
-	println!("- Enabling X feature in {}", path.display());
+	println!("- Enabling evm-tracing feature in {}", path.display());
 	let Some(Item::Table(features)) = toml.get_mut("features") else {
 		panic!("cannot get features table");
 	};

--- a/scripts/migrate-imported.rs
+++ b/scripts/migrate-imported.rs
@@ -127,13 +127,13 @@ fn update_root_toml(args: &Args) -> Vec<String> {
 
 		// Add feature "runtime-1600" to "evm-tracing-event"
 		if dep_name == "evm-tracing-events" {
-			let Value::Array(ref mut features) = dep_table.get_or_insert("features", Array::new()) else {
+			let Value::Array(features) = dep_table.get_or_insert("features", Array::new()) else {
 				panic!("expected features of `{dep_name}` to be an array or missing");
 			};
 			features.push("runtime-1600");
 		}
 		if dep_name == "moonbeam-rpc-primitives-debug" {
-			let Value::Array(ref mut features) = dep_table.get_or_insert("features", Array::new()) else {
+			let Value::Array(features) = dep_table.get_or_insert("features", Array::new()) else {
 				panic!("expected features of `{dep_name}` to be an array or missing");
 			};
 			features.push("runtime-2900");

--- a/tracing/shared/primitives/rpc/debug/Cargo.toml
+++ b/tracing/shared/primitives/rpc/debug/Cargo.toml
@@ -27,6 +27,7 @@ default = [ "std" ]
 
 before_700 = []
 _700_to_1200 = []
+runtime-2900 = []
 
 std = [
 	"parity-scale-codec/std",

--- a/tracing/shared/primitives/rpc/debug/src/lib.rs
+++ b/tracing/shared/primitives/rpc/debug/src/lib.rs
@@ -28,7 +28,25 @@ use ethereum::TransactionV2 as Transaction;
 use ethereum_types::{H160, H256, U256};
 use sp_std::vec::Vec;
 
-#[cfg(all(not(feature = "before_700"), not(feature = "_700_to_1200")))]
+#[cfg(feature = "runtime-2900")]
+sp_api::decl_runtime_apis! {
+	#[api_version(5)]
+	pub trait DebugRuntimeApi {
+		fn trace_transaction(
+			extrinsics: Vec<Block::Extrinsic>,
+			transaction: &Transaction,
+			transaction: &Block::Header,
+		) -> Result<(), sp_runtime::DispatchError>;
+
+		fn trace_block(
+			extrinsics: Vec<Block::Extrinsic>,
+			known_transactions: Vec<H256>,
+			transaction: &Block::Header,
+		) -> Result<(), sp_runtime::DispatchError>;
+	}
+}
+
+#[cfg(all(not(feature = "before_700"), not(feature = "_700_to_1200"), not(feature = "runtime-2900")))]
 sp_api::decl_runtime_apis! {
 	#[api_version(4)]
 	pub trait DebugRuntimeApi {


### PR DESCRIPTION
This API change is necessary new runtimes after RT2900. The tracing API on the runtime side will now be responsible of performing the block initialisation.