### PR TITLE
CI Maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for github-actions
+  - package-ecosystem: "github-actions"
+    # Look for a `Dockerfile` in the `root` directory
+    directory: "/"
+    # Check for updates once a month
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,8 @@ jobs:
   check-tracing-runtime:
     name: "Check tracing runtime"
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: bare-metal
     needs: ["list-spec-versions"]
     strategy:
       matrix:


### PR DESCRIPTION

- Use bare-metal to run the runtime checks
- Add dependabot config to check for outdated dependencies