### PR TITLE
Don't enable v5 tracing API by default

### DIFF
--- a/scripts/migrate-imported.rs
+++ b/scripts/migrate-imported.rs
@@ -127,16 +127,10 @@ fn update_root_toml(args: &Args) -> Vec<String> {
 
 		// Add feature "runtime-1600" to "evm-tracing-event"
 		if dep_name == "evm-tracing-events" {
-			let Value::Array(ref mut features) = dep_table.get_or_insert("features", Array::new()) else {
-				panic!("expected features of `{dep_name}` to be an array or missing");
-			};
-			features.push("runtime-1600");
-		}
-		if dep_name == "moonbeam-rpc-primitives-debug" {
 			let Value::Array(features) = dep_table.get_or_insert("features", Array::new()) else {
 				panic!("expected features of `{dep_name}` to be an array or missing");
 			};
-			features.push("runtime-2900");
+			features.push("runtime-1600");
 		}
 
 		// No path => not moonbeam crate.


### PR DESCRIPTION
Instead of enabling the v5 API when building the runtime overrides, we can instead enable the feature directly from the moonbeam repo. It will allow other PRs to run tracing tests while we don't update moonbeam to use polkadot-sdk 1.7.2