### PR TITLE
feat: add trace_call to DebugRuntimeApi trait

### DIFF
--- a/tracing/shared/primitives/rpc/debug/Cargo.toml
+++ b/tracing/shared/primitives/rpc/debug/Cargo.toml
@@ -28,6 +28,7 @@ default = [ "std" ]
 before_700 = []
 _700_to_1200 = []
 runtime-2900 = []
+runtime-3000 = []
 
 std = [
 	"parity-scale-codec/std",

--- a/tracing/shared/primitives/rpc/debug/src/lib.rs
+++ b/tracing/shared/primitives/rpc/debug/src/lib.rs
@@ -76,7 +76,12 @@ sp_api::decl_runtime_apis! {
 	}
 }
 
-#[cfg(all(not(feature = "before_700"), not(feature = "_700_to_1200"), not(feature = "runtime-2900")))]
+#[cfg(all(
+	not(feature = "before_700"),
+	not(feature = "_700_to_1200"),
+	not(feature = "runtime-2900"),
+	not(feature = "runtime-3000")
+))]
 sp_api::decl_runtime_apis! {
 	#[api_version(4)]
 	pub trait DebugRuntimeApi {

--- a/tracing/shared/primitives/rpc/debug/src/lib.rs
+++ b/tracing/shared/primitives/rpc/debug/src/lib.rs
@@ -28,6 +28,36 @@ use ethereum::TransactionV2 as Transaction;
 use ethereum_types::{H160, H256, U256};
 use sp_std::vec::Vec;
 
+#[cfg(feature = "runtime-3000")]
+sp_api::decl_runtime_apis! {
+	#[api_version(5)]
+	pub trait DebugRuntimeApi {
+		fn trace_transaction(
+			extrinsics: Vec<Block::Extrinsic>,
+			transaction: &Transaction,
+			header: &Block::Header,
+		) -> Result<(), sp_runtime::DispatchError>;
+
+		fn trace_block(
+			extrinsics: Vec<Block::Extrinsic>,
+			known_transactions: Vec<H256>,
+			header: &Block::Header,
+		) -> Result<(), sp_runtime::DispatchError>;
+
+		fn trace_call(
+			from: H160,
+			to: H160,
+			data: Vec<u8>,
+			value: U256,
+			gas_limit: U256,
+			max_fee_per_gas: Option<U256>,
+			max_priority_fee_per_gas: Option<U256>,
+			nonce: Option<U256>,
+			access_list: Option<Vec<(H160, Vec<H256>)>>,
+		) -> Result<(), sp_runtime::DispatchError>;		
+	}
+}
+
 #[cfg(feature = "runtime-2900")]
 sp_api::decl_runtime_apis! {
 	#[api_version(5)]


### PR DESCRIPTION
This PR adds a new method named `trace_call` to `DebugRuntimeApi`, which can be enabled by setting the `runtime-3000` flag. This new API method will be used by `debug_traceCall` rpc call.